### PR TITLE
Fix installing on Windows by specifying encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os.path
 from setuptools import setup
 
-with open(os.path.join(os.path.dirname(__file__), "README.md")) as f:
+with open(os.path.join(os.path.dirname(__file__), "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 about = {}


### PR DESCRIPTION
In a windows environment, if the encoding is not specified, ASCII is expected. This creates errors when running setup.py when the README (or other files) contain emojis or other non-ascii characters. This fixes this at least for the README, not sure if there are other instances of this.