### PR TITLE
Image.Resampling.LANCZOS instead of Image.ANTIALIAS deprecated in Pillow 10

### DIFF
--- a/videohash/collagemaker.py
+++ b/videohash/collagemaker.py
@@ -180,7 +180,7 @@ class MakeCollage:
 
             # scale the opened frame images
             frame.thumbnail(
-                (scaled_frame_image_width, scaled_frame_image_height), Image.ANTIALIAS
+                (scaled_frame_image_width, scaled_frame_image_height), Image.Resampling.LANCZOS
             )
 
             # set the value of x to that of i's value.


### PR DESCRIPTION
[Pillow's release notes](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html)

[PR](https://github.com/akamhy/imagedominantcolor/pull/3) also done in your other project imagedominantcolor.